### PR TITLE
Fixing Keccak test case - Update Keccak.t.sol

### DIFF
--- a/Keccak/test/Keccak.t.sol
+++ b/Keccak/test/Keccak.t.sol
@@ -44,11 +44,11 @@ contract KeccakTest is Test {
 
             mstore(0x04, value2)
             success2 := call(gas(), addr, 0x00, 0x00, 0x24, 0x80, 0x20)
-            hash1Correct := eq(hash2, mload(0x80))
+            hash2Correct := eq(hash2, mload(0x80))
 
             mstore(0x04, value3)
             success3 := call(gas(), addr, 0x00, 0x00, 0x24, 0x80, 0x20)
-            hash1Correct := eq(hash3, mload(0x80))
+            hash3Correct := eq(hash3, mload(0x80))
         }
 
         assertEq(success1, true, "keccak.keccak(55) call reverted");


### PR DESCRIPTION
hash1Correct was assigned instead of hash2Correct and hash3Correct