### PR TITLE
Updated tests for issue raised in Donations

### DIFF
--- a/Donations/test/Donations.t.sol
+++ b/Donations/test/Donations.t.sol
@@ -31,6 +31,16 @@ contract DonationsTest is Test {
             "expected amountDonated by address(BEEF) to be 1 ether"
         );
 
+        vm.deal(address(0xBEEF), 1 ether);
+        vm.prank(address(0xBEEF));
+        (success, ) = address(donations).call{value: 1 ether}("");
+        require(success, "Send ether failed");
+        assertEq(
+            donations.amountDonated(address(0xBEEF)),
+            2 ether,
+            "expected amountDonated by address(BEEF) to be 2 ether"
+        );
+
         vm.deal(address(0xCAFE), 1 ether);
         vm.prank(address(0xCAFE));
         (success, ) = address(donations).call{value: 1 ether}("");

--- a/TimelockEscrow/test/TimeLockEscrow.t.sol
+++ b/TimelockEscrow/test/TimeLockEscrow.t.sol
@@ -34,6 +34,9 @@ contract TimelockEscrowTest is Test {
         uint256 timelockEscrowBalanceBefore = address(timelockEscrow).balance;
         uint256 sellerBefore = address(timelockEscrow).balance;
 
+        vm.expectRevert();
+        timelockEscrow.createBuyOrder();
+
         vm.prank(SELLER);
         timelockEscrow.sellerWithdraw(address(this));
 
@@ -72,6 +75,9 @@ contract TimelockEscrowTest is Test {
 
         uint256 timelockEscrowBalanceBefore = address(timelockEscrow).balance;
         uint256 buyerBefore = address(this).balance;
+        
+        vm.expectRevert();
+        timelockEscrow.createBuyOrder();
 
         timelockEscrow.buyerWithdraw();
 


### PR DESCRIPTION
The test in Donations.t.sol does not account for multiple donations as stated in the Donations.sol file.
This could allow a reset of the amountDonated mapping via assignment (=) instead of an increment (using +=).
i.e.
`amountDonated[msg.sender] = msg.value;    // runs and re-assigns the mapping on every run`
instead of
`amountDonated[msg.sender] += msg.value;  // to increment the mapping per address`

Consider including the extra check in the tests.