### PR TITLE
correction in typecast

### DIFF
--- a/Typecast/test/Typecast.t.sol
+++ b/Typecast/test/Typecast.t.sol
@@ -16,11 +16,12 @@ contract TypecastTest is Test {
         typecast.typeCast{value: 1 ether}();
 
         bool success;
+        vm.deal(address(this), 500000000000000000000000000000 ether);
 
         assembly {
             mstore(
                 0x00,
-                0x3fe8e3f000000000000000000000000000000000000000000000000000000000
+                0x12e9b56d00000000000000000000000000000000000000000000000000000000
             )
             let addr := sload(typecast.slot)
             success := call(gas(), addr, addr, 0x00, 0x04, 0x00, 0x00)


### PR DESCRIPTION
`0x3fe8e3f000000000000000000000000000000000000000000000000000000000` is address of contract we need function signature `0x12e9b56d00000000000000000000000000000000000000000000000000000000`. 

Added Vm deal since it was throwing EVM out of funds error . 

Both of them caused failed test for solution
`require (msg.value == uint256(uint160(address(this))), "Does not match");`