### PR TITLE
Added assert statements and test cases for UncheckedTest

### DIFF
--- a/Unchecked/test/Unchecked.t.sol
+++ b/Unchecked/test/Unchecked.t.sol
@@ -11,10 +11,27 @@ contract UncheckedTest is Test {
         uncheckedContract = new Unchecked();
     }
 
-    function testUnchecked() external {
-        uint256 res = uncheckedContract.getNumber(10);
-        uint256 res1 = uncheckedContract.getNumber(0);
-        uint256 res2 = uncheckedContract.getNumber(50);
-        uint256 res3 = uncheckedContract.getNumber(20);
+    function testUnchecked() public {
+        uint256 result = uncheckedContract.getNumber(10);
+        uint256 expected = type(uint256).max - 100 + 1 + 10;
+        assertEq(result, expected, "unchecked should return underflow value");
+    }
+
+    function testUnchecked2() public {
+        uint256 result = uncheckedContract.getNumber(100);
+        uint256 expected = 0;
+        assertEq(result, expected, "unchecked should return underflow value");
+    }
+
+    function testUnchecked3() public {
+        uint256 result = uncheckedContract.getNumber(0);
+        uint256 expected = type(uint256).max - 100 + 1;
+        assertEq(result, expected, "unchecked should return underflow value");
+    }
+
+    function testUnchecked4() public {
+        uint256 result = uncheckedContract.getNumber(type(uint256).max);
+        uint256 expected = type(uint256).max - 100;
+        assertEq(result, expected, "unchecked should return underflow value");
     }
 }


### PR DESCRIPTION
This pull request improves the UncheckedTest contract by:
- Adding missing `assertEq` statements to verify the correctness of returned values.
- Implementing four new test cases to cover different scenarios:
  1. `testUnchecked` tests the behavior with a positive value (10).
  2. `testUnchecked2` tests with a value of 100 to check for expected results of zero underflows.
  3. `testUnchecked3` tests with 0 to verify the expected underflow behavior.
  4. `testUnchecked4` tests with `type(uint256).max` to validate the edge case.