### PR TITLE
Improved test coverage for array exercises - FilterOddNumbers and Mean

### DIFF
--- a/FilterOddNumbers/test/FilterOddNumbers.t.sol
+++ b/FilterOddNumbers/test/FilterOddNumbers.t.sol
@@ -48,4 +48,84 @@ contract FilterOddNumbersTest is Test {
         assertEq(filter2[4], 2, "expected 2");
         assertEq(filter2[5], 20, "expected 20");
     }
+
+    // Test case when the array is already all even numbers
+    function testAllEven() external {
+        uint256[] memory evenArray = new uint256[](5);
+        evenArray[0] = 2;
+        evenArray[1] = 4;
+        evenArray[2] = 6;
+        evenArray[3] = 8;
+        evenArray[4] = 10;
+
+        uint256[] memory filteredArray = filterContract.filterOdd(evenArray);
+
+        assertEq(filteredArray.length, 5, "expected length 5");
+        assertEq(filteredArray[0], 2, "expected 2");
+        assertEq(filteredArray[1], 4, "expected 4");
+        assertEq(filteredArray[2], 6, "expected 6");
+        assertEq(filteredArray[3], 8, "expected 8");
+        assertEq(filteredArray[4], 10, "expected 10");
+    }
+
+    // Test case when the array has all odd numbers
+    function testAllOdd() external {
+        uint256[] memory oddArray = new uint256[](5);
+        oddArray[0] = 1;
+        oddArray[1] = 3;
+        oddArray[2] = 5;
+        oddArray[3] = 7;
+        oddArray[4] = 9;
+
+        uint256[] memory filteredArray = filterContract.filterOdd(oddArray);
+
+        assertEq(filteredArray.length, 0, "expected length 0");
+    }
+
+    // Test case with an empty array
+    function testEmptyArray() external {
+        uint256[] memory emptyArray = new uint256[](0);
+        uint256[] memory filteredArray = filterContract.filterOdd(emptyArray);
+
+        assertEq(filteredArray.length, 0, "expected length 0");
+    }
+
+    // Test case with a single even number
+    function testSingleEvenNumber() external {
+        uint256[] memory singleEven = new uint256[](1);
+        singleEven[0] = 2;
+
+        uint256[] memory filteredArray = filterContract.filterOdd(singleEven);
+
+        assertEq(filteredArray.length, 1, "expected length 1");
+        assertEq(filteredArray[0], 2, "expected 2");
+    }
+
+    // Test case with a single odd number
+    function testSingleOddNumber() external {
+        uint256[] memory singleOdd = new uint256[](1);
+        singleOdd[0] = 1;
+
+        uint256[] memory filteredArray = filterContract.filterOdd(singleOdd);
+
+        assertEq(filteredArray.length, 0, "expected length 0");
+    }
+
+    // Test case with a large array
+    function testLargeArray() external {
+        uint256[] memory largeArray = new uint256[](50);
+        uint256 evenCount = 0;
+
+        // Fill the array with numbers and count even numbers
+        for (uint256 i = 0; i < largeArray.length; i++) {
+            largeArray[i] = i;
+            if (i % 2 == 0) {
+                evenCount++;
+            }
+        }
+
+        uint256[] memory filteredArray = filterContract.filterOdd(largeArray);
+
+        assertEq(filteredArray.length, evenCount, "expected even count"); // Length should match even number count
+    }
 }

--- a/Mean/test/Mean.t.sol
+++ b/Mean/test/Mean.t.sol
@@ -11,7 +11,7 @@ contract MeanTest is Test {
         mean = new Mean();
     }
 
-    function testMean() public {
+    function testMeanx() external {
         uint256[] memory x = new uint256[](5);
         x[0] = 5;
         x[1] = 10;
@@ -19,6 +19,10 @@ contract MeanTest is Test {
         x[3] = 20;
         x[4] = 25;
 
+        assertEq(mean.mean(x), 15, "expected mean of arr 'x' is 15");
+    }
+
+    function testMeany() external {
         uint256[] memory y = new uint256[](5);
         y[0] = 5;
         y[1] = 10;
@@ -26,6 +30,10 @@ contract MeanTest is Test {
         y[3] = 19;
         y[4] = 25;
 
+        assertEq(mean.mean(y), 14, "expected mean of array 'y' is 14");
+    }
+
+    function testMeanMostlyZeroes() external {
         uint256[] memory z = new uint256[](5);
         z[0] = 0;
         z[1] = 0;
@@ -33,8 +41,35 @@ contract MeanTest is Test {
         z[3] = 0;
         z[4] = 0;
 
-        assertEq(mean.mean(x), 15, "mean of arr 'x' is 15");
-        assertEq(mean.mean(y), 14, "mean of arr 'y' is 14");
-        assertEq(mean.mean(z), 0, "mean of arr 'z' is 0");
+        assertEq(mean.mean(z), 0, "expected mean of arr 'z' is 0");
+    }
+
+    function testMeanSingleElement() external {
+        uint256[] memory singleElement = new uint256[](1);
+        singleElement[0] = 42;
+        assertEq(
+            mean.mean(singleElement),
+            42,
+            "expected 42, because the answer to ultimate question of life is 42. Also, mean of a single-element array should be element itself"
+        );
+    }
+
+    function testMeanLargeNumbers() external {
+        uint256[] memory largeNumbers = new uint256[](3);
+        largeNumbers[0] = 1e42;
+        largeNumbers[1] = 1e42;
+        largeNumbers[2] = 1e42;
+
+        assertEq(
+            mean.mean(largeNumbers),
+            1e42,
+            "Mean of large numbers should be the large number itself"
+        );
+    }
+
+    function testMeanEmptyArray() external {
+        uint256[] memory emptyArray = new uint256[](0);
+        vm.expectRevert(abi.encodeWithSignature("Panic(uint256)", 0x12));
+        mean.mean(emptyArray);
     }
 }


### PR DESCRIPTION
This PR introduces improvement to test cases for `FilterOddNumbers` and `Mean` contracts:

#### 1. **FilterOddNumbers Contract**:
- Added edge cases to handle:
  - Empty arrays
  - Arrays with all even numbers
  - Arrays with all odd numbers
  - Arrays with a single even number
  - Arrays with a single odd number
- Added array length checks to ensure the result array matches the expected size.
- Included tests for large arrays to check correctness.

#### 2. **Mean Contract**:
- Re-structured tests as one function, one type of test and added comprehensive tests for the `mean` function.
- Covered edge cases, including:
  - Empty array (handled with `Panic` error check for division by zero)
  - Single-element arrays (mean should be the element itself)
  - Large numbers to ensure proper handling of large sums
- Implemented `vm.expectRevert` for the Panic error (`0x12` for division by zero).