### PR TITLE
fix: PriceIsRight tests

### DIFF
--- a/PriceIsRight/foundry.toml
+++ b/PriceIsRight/foundry.toml
@@ -2,5 +2,6 @@
 src = 'src'
 out = 'out'
 libs = ['lib']
+allow_internal_expect_revert = true
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
Test is failing `[FAIL: call didn't revert at a lower depth than cheatcode call depth` due to recent changes in foundry https://github.com/foundry-rs/foundry/issues/7238
Proposed solution in https://github.com/PaulRBerg/prb-math/issues/248 