### PR TITLE
fix: replace gas-based immutability check with direct storage slot check

### DIFF
--- a/Immutable/test/Immutable.t.sol
+++ b/Immutable/test/Immutable.t.sol
@@ -10,24 +10,21 @@ contract ContractImmutableTest is Test {
     function setUp() public {}
 
     function testContractImmutable() external {
-        uint256 startGas = gasleft();
         contractImmutable = new ContractImmutable(10);
-        uint256 gasUsed = startGas - gasleft();
-
-        assertEq(contractImmutable.value(), 10, "expected value to be 10");
-
-        if (gasUsed < 90000) assertFalse(false);
-        else assertFalse(true);
+        bytes32 slot0 = vm.load(address(contractImmutable), bytes32(uint256(0)));
+        // since `value` is immutable, it won't be in storage
+        assertEq(slot0, bytes32(0));
+        assertEq(contractImmutable.value(), 10);
     }
 
     function testContractImmutable2() external {
-        uint256 startGas = gasleft();
         contractImmutable = new ContractImmutable(550);
-        uint256 gasUsed = startGas - gasleft();
-
-        assertEq(contractImmutable.value(), 550, "expected value to be 550");
-
-        if (gasUsed < 90000) assertFalse(false);
-        else assertFalse(true);
+        bytes32 slot0 = vm.load(address(contractImmutable), bytes32(uint256(0)));
+        // since `value` is immutable, it won't be in storage
+        assertEq(slot0, bytes32(0));
+        assertEq(contractImmutable.value(), 550);
     }
-}
+
+        
+    }
+


### PR DESCRIPTION
### Closes #50 
### Summary
The current tests for `ContractImmutable` check immutability indirectly by measuring deployment gas.  
Since deployment gas can vary depending on the environment, this may cause the tests to fail even when `value` is correctly declared as `immutable`.

### Changes
- Updated the tests to confirm immutability by checking that `value` does not occupy a storage slot.
- Used `vm.load` to verify that slot `0` is empty, while still asserting the correct runtime value.

### Benefits
- Makes the test more reliable and deterministic.
- Directly verifies immutability in a way that is consistent with how Solidity compiles immutable variables.

### Example
```solidity
bytes32 slot0 = vm.load(address(contractImmutable), bytes32(uint256(0)));
assertEq(slot0, bytes32(0));
assertEq(contractImmutable.value(), 550);
